### PR TITLE
fix typescript comile error

### DIFF
--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -34,7 +34,7 @@
         "@theia/plugin-packager": "latest",
         "rimraf": "2.6.2",
         "typescript-formatter": "7.2.2",
-        "typescript": "2.9.2"<%
+        "typescript": "3.5.3"<%
         if (params.isFrontend) { %>,
         "ts-loader": "^4.1.0",
         "clean-webpack-plugin": "^0.1.19",        


### PR DESCRIPTION
Update the typescript dev dependency version to 3.5.3. Fix typescript compilation error. 

[#17867](https://github.com/eclipse/che/issues/17867)