### PR TITLE
fix: Add skipLibCheck to tsconfig.json

### DIFF
--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -1,68 +1,68 @@
 {
-      "name": "<%= params.packageName %>",
-      "publisher": "<%= params.publisher %>",
-      "keywords": [
-        "theia-plugin"
-      ],
-      "version": "<%= params.version %>",<% 
-      if (params.description) { %>
-      "description": "<%= params.description %>",
-      <%} %><% 
-      if (params.author) { %>
-      "author": "<%= params.author %>",
-      <% } %><% 
-      if (params.license) { %>
-      "license": "<%= params.license.id %>",
-      <% } %><% 
-      if (params.githubURL) { %>
-      "repository": {
-        "type": "git",
-        "url": "<%= params.githubURL %>.git"
-      },
-      "bugs": {
-        "url": "<%= params.githubURL %>/issues"
-      },
-      "homepage": "<%= params.githubURL %>",<% } %>
-      "files": [
-        "src"
-      ],
-      "activationEvents": [
-        "*"
-      ],
-      "devDependencies": {
-        "@theia/plugin": "<%= params.theiaVersion %>",
-        "@theia/plugin-packager": "latest",
-        "rimraf": "2.6.2",
-        "typescript-formatter": "7.2.2",
-        "typescript": "3.5.3"<%
-        if (params.isFrontend) { %>,
-        "ts-loader": "^4.1.0",
-        "clean-webpack-plugin": "^0.1.19",        
-        "webpack": "^4.1.1",
-        "webpack-cli": "^3.1.1"<% } %>
-      },
-      "scripts": {
-        "prepare": "yarn run clean && yarn run build",
-        "clean": "rimraf lib",
-        "format-code": "tsfmt -r",<%
-        if (params.isFrontend) { %>
-        "watch": "webpack-cli -w --config webpack.config.js",
-        "compile": "webpack-cli --config webpack.config.js",
-        <% } %><%
-        if (params.isBackend) { %>
-        "watch": "tsc -watch",
-        "compile": "tsc", <% } %>
-        "build": "yarn run format-code && yarn run compile && theia-plugin pack"
-      },
-      "engines": {
-        "theiaPlugin": "<%= params.theiaVersion %>"
-      },
-      "theiaPlugin": {
-          <% if (params.isFrontend) { %>
-            "frontend": "dist/<%= params.pluginDistPath %>"
-          <% } %>
-          <% if (params.isBackend) { %>
-            "backend": "lib/<%= params.pluginDistPath %>"
-          <% } %>
-      }
+  "name": "<%= params.packageName %>",
+  "publisher": "<%= params.publisher %>",
+  "keywords": [
+    "theia-plugin"
+  ],
+  "version": "<%= params.version %>",<%
+  if (params.description) { %>
+  "description": "<%= params.description %>",
+  <%} %><%
+  if (params.author) { %>
+  "author": "<%= params.author %>",
+  <% } %><%
+  if (params.license) { %>
+  "license": "<%= params.license.id %>",
+  <% } %><%
+  if (params.githubURL) { %>
+  "repository": {
+    "type": "git",
+    "url": "<%= params.githubURL %>.git"
+  },
+  "bugs": {
+    "url": "<%= params.githubURL %>/issues"
+  },
+  "homepage": "<%= params.githubURL %>",<% } %>
+  "files": [
+    "src"
+  ],
+  "activationEvents": [
+    "*"
+  ],
+  "devDependencies": {
+    "@theia/plugin": "<%= params.theiaVersion %>",
+    "@theia/plugin-packager": "latest",
+    "rimraf": "2.6.2",
+    "typescript-formatter": "7.2.2",
+    "typescript": "3.5.3"<%
+    if (params.isFrontend) { %>,
+    "ts-loader": "^4.1.0",
+    "clean-webpack-plugin": "^0.1.19",
+    "webpack": "^4.1.1",
+    "webpack-cli": "^3.1.1"<% } %>
+  },
+  "scripts": {
+    "prepare": "yarn run clean && yarn run build",
+    "clean": "rimraf lib",
+    "format-code": "tsfmt -r",<%
+    if (params.isFrontend) { %>
+    "watch": "webpack-cli -w --config webpack.config.js",
+    "compile": "webpack-cli --config webpack.config.js",
+    <% } %><%
+    if (params.isBackend) { %>
+    "watch": "tsc -watch",
+    "compile": "tsc", <% } %>
+    "build": "yarn run format-code && yarn run compile && theia-plugin pack"
+  },
+  "engines": {
+    "theiaPlugin": "<%= params.theiaVersion %>"
+  },
+  "theiaPlugin": {
+    <% if (params.isFrontend) { %>
+      "frontend": "dist/<%= params.pluginDistPath %>"
+    <% } %>
+    <% if (params.isBackend) { %>
+      "backend": "lib/<%= params.pluginDistPath %>"
+    <% } %>
+  }
 }

--- a/templates/base/tsconfig.json
+++ b/templates/base/tsconfig.json
@@ -1,27 +1,28 @@
 {
-    "compilerOptions": {
-        "strict": true,
-        "experimentalDecorators": true,
-        "noUnusedLocals": true,
-        "emitDecoratorMetadata": true,
-        "downlevelIteration": true,
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "target": "es6",
-        "lib": [
-            "es6",
-            <% if (params.isFrontend) { %>
-            "webworker"
-            <% } %>
-            <% if (params.isBackend) { %>
-            "webworker"
-            <%} %>
-        ],
-        "sourceMap": true,
-        "rootDir": "src",
-        "outDir": "lib"
-    },
-    "include": [
-        "src"
-    ]
+  "compilerOptions": {
+    "strict": true,
+    "experimentalDecorators": true,
+    "noUnusedLocals": true,
+    "emitDecoratorMetadata": true,
+    "downlevelIteration": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es6",
+    "lib": [
+      "es6",
+      <% if (params.isFrontend) { %>
+      "webworker"
+      <% } %>
+      <% if (params.isBackend) { %>
+      "webworker"
+      <%} %>
+    ],
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "lib",
+    "skipLibCheck": true
+  },
+  "include": [
+    "src"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     ],
     "sourceMap": true,
     "rootDir": "src",
-    "outDir": "generators"
+    "outDir": "generators",
+    "skipLibCheck": true
   },
   "include": [
     "src"


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

This PR:
- Adds skipLibCheck: false to tsconfig.json
- Improves formatting of tsconfig.json and package.json

Solves issue https://github.com/eclipse/che/issues/19889

It's a duplicate of unmerged PR https://github.com/eclipse/theia-generator-plugin/pull/25
